### PR TITLE
Replace aws sdk to 'request' method offered serverless framework

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,33 +2,12 @@
 
 const _ = require('lodash');
 
-let _apiGatewayService = null;
-let _cloudFormationService = null;
-
 class ServerlessApiGatewayXray {
-
   get stackName() {
     return `${this.serverless.service.service}-${this.options.stage}`;
   }
 
-  get apiGatewayService() {
-
-    if (!_apiGatewayService)
-      _apiGatewayService = new this.awsService.sdk.APIGateway({ region: this.options.region });
-
-    return _apiGatewayService;
-  }
-
-  get cloudFormationService() {
-
-    if (!_cloudFormationService)
-      _cloudFormationService = new this.awsService.sdk.CloudFormation({ region: this.options.region });
-
-    return _cloudFormationService;
-  }
-
   constructor(serverless, options) {
-
     this.options = options;
     this.serverless = serverless;
     this.awsService = this.serverless.getProvider('aws');
@@ -46,41 +25,32 @@ class ServerlessApiGatewayXray {
   }
 
   getStackResources() {
-    return new Promise((resolve, reject) => {
-      this.cloudFormationService.describeStackResources({ StackName: this.stackName }, (err, data) => {
-        if (err) return reject(err);
-        resolve(data);
-      });
-    });
+    return this.awsService.request('CloudFormation', 'describeStackResources', { StackName: this.stackName });
   }
 
   enableApiGatewayXray(data) {
-
     const apiGatewayResources = _.filter(data.StackResources, { ResourceType: 'AWS::ApiGateway::RestApi' });
 
     const promises = _.map(apiGatewayResources, item => {
       return new Promise((resolve, reject) => {
-        // try {
-          const params = {
-            restApiId: item.PhysicalResourceId,
-            stageName: this.options.stage,
-            patchOperations: [
-              {
-                op: 'replace',
-                path: '/tracingEnabled',
-                value: this.serverless.service.custom.apiGatewayXray.toString()
-              }
-            ]
-          };
+        const params = {
+          restApiId: item.PhysicalResourceId,
+          stageName: this.options.stage,
+          patchOperations: [
+            {
+              op: 'replace',
+              path: '/tracingEnabled',
+              value: this.serverless.service.custom.apiGatewayXray.toString()
+            }
+          ]
+        };
 
-          this.apiGatewayService.updateStage(params, (err, data) => {
-            if (err) {
-              console.log(err)
-              return reject(err)
-            };
-            resolve(`API gateway xray ${this.serverless.service.custom.apiGatewayXray}`);
-          });
-
+        this.awsService.request('APIGateway', 'updateStage', params).then((data) => {
+          resolve(`API gateway xray ${this.serverless.service.custom.apiGatewayXray}`);
+        }).catch((err) => {
+          console.log(err);
+          reject(err);
+        });
 
       });
     });


### PR DESCRIPTION
### WHAT
Replaced AWS SDK to `request` method offered by serverless frameowrk

### WHY
Origin code uses AWS SDK on the AWS provider object offered by the serverless framework. But it is not injected of the custom AWS credentials written on the serverless.yaml.
```yaml
...
provider:
  name: aws
  profile: my-aws-profile  # one of the named profiles stored in the config and credentials files for aws cli.
...
```

Origin code creates AWS SDK objects without credentials. That means it only uses the default credentials. On the other hand, it's possible using the custom AWS credentials when `request` method on the AWS provider object uses offered by the serverless framework.
